### PR TITLE
Extract error codes from SOAP faults

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -76,17 +76,27 @@ func (c *connection) post(ctx context.Context, payload []byte) (*EnvelopeRespons
 		SetHeader("Content-Type", "application/xml").
 		SetContentLength(true).
 		SetBody(payload).
-		SetResult(out)
+		SetResult(out).
+		// SOAP faults may also be sent alongside an error status code, and
+		// will only be parsed if we define them as the error result.
+		SetError(out)
 
 	res, err := req.Post("")
 	if err != nil {
 		return nil, err
 	}
-	if res.StatusCode() != http.StatusOK {
-		return nil, ErrValidation.WithCode(strconv.Itoa(res.StatusCode())).WithMessage(res.String())
-	}
+	// Always prefer the fault, it describes the problem in much more detail
+	// than the status code alone.
 	if out.Body.Fault != nil {
-		return nil, ErrValidation.WithMessage(out.Body.Fault.Message).WithCode(out.Body.Fault.Code)
+		return nil, out.Body.Fault.Err()
+	}
+	if res.StatusCode() != http.StatusOK {
+		e := ErrValidation
+		if res.StatusCode() >= http.StatusInternalServerError {
+			// Remote service problem, may be worth trying again later.
+			e = ErrServer
+		}
+		return nil, e.WithCode(strconv.Itoa(res.StatusCode())).WithMessage(res.String())
 	}
 
 	return out, nil

--- a/envelope.go
+++ b/envelope.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"encoding/xml"
 	"fmt"
+	"regexp"
+	"strings"
 	"time"
 )
 
@@ -60,6 +62,60 @@ type EnvelopeResponse struct {
 type Fault struct {
 	Code    string `xml:"faultcode"`
 	Message string `xml:"faultstring"`
+}
+
+// faultCodeRegexp is used to extract the VeriFactu error code embedded inside
+// the fault string. Errors detected in the header of a request are always
+// reported as SOAP faults, and the fault structure has no field available for
+// the code, so the gateway includes it in the human readable message, e.g.
+// `Codigo[4104].Error en la cabecera: ...`.
+var faultCodeRegexp = regexp.MustCompile(`^Codigo\[(\d+)\]\.?\s*`)
+
+// faultWhitespaceRegexp matches the runs of whitespace used by the gateway to
+// indent the details appended to fault strings.
+var faultWhitespaceRegexp = regexp.MustCompile(`\s+`)
+
+// ErrorCode provides the VeriFactu error code of the fault, if one could be
+// extracted from the fault string.
+func (f *Fault) ErrorCode() string {
+	m := faultCodeRegexp.FindStringSubmatch(f.faultString())
+	if m == nil {
+		return ""
+	}
+	return m[1]
+}
+
+// ErrorMessage provides the fault string without the error code prefix and
+// with any indentation reduced to single spaces.
+func (f *Fault) ErrorMessage() string {
+	return strings.TrimSpace(faultCodeRegexp.ReplaceAllString(f.faultString(), ""))
+}
+
+// Err converts the fault into a structured error that the consumer can use to
+// determine how the issue should be handled.
+func (f *Fault) Err() *Error {
+	e := ErrValidation
+	if f.serverSide() {
+		// Something went wrong inside the gateway, the request may be
+		// worth sending again later.
+		e = ErrServer
+	}
+	return e.WithCode(f.ErrorCode()).WithMessage(f.ErrorMessage())
+}
+
+// serverSide determines if the fault was caused by the remote service instead
+// of the contents of our request. The prefix of the fault code is defined by
+// the server, so only the local part can be compared.
+func (f *Fault) serverSide() bool {
+	code := f.Code
+	if _, after, found := strings.Cut(code, ":"); found {
+		code = after
+	}
+	return strings.EqualFold(code, "Server")
+}
+
+func (f *Fault) faultString() string {
+	return strings.TrimSpace(faultWhitespaceRegexp.ReplaceAllString(f.Message, " "))
 }
 
 func newEnvelope() *Envelope {

--- a/envelope_test.go
+++ b/envelope_test.go
@@ -1,0 +1,88 @@
+package verifactu_test
+
+import (
+	"encoding/xml"
+	"testing"
+
+	verifactu "github.com/invopop/gobl.verifactu"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnvelopeResponseFault(t *testing.T) {
+	t.Run("header error", func(t *testing.T) {
+		data := []byte(`<?xml version="1.0" encoding="UTF-8"?>
+			<env:Envelope xmlns:env="http://schemas.xmlsoap.org/soap/envelope/">
+				<env:Body>
+					<env:Fault>
+						<faultcode>env:Client</faultcode>
+						<faultstring>Codigo[4104].Error en la cabecera: el valor del campo NIF del bloque ObligadoEmision no est&#225; identificado..
+						NIF:54387763P. NOMBRE_RAZON:Sample Consumer
+						</faultstring>
+					</env:Fault>
+				</env:Body>
+			</env:Envelope>`)
+
+		res := new(verifactu.EnvelopeResponse)
+		require.NoError(t, xml.Unmarshal(data, res))
+		require.NotNil(t, res.Body.Fault)
+
+		err := res.Body.Fault.Err()
+		assert.ErrorIs(t, err, verifactu.ErrValidation)
+		assert.Equal(t, "4104", err.Code())
+		assert.Equal(t, "Error en la cabecera: el valor del campo NIF del bloque ObligadoEmision no está identificado.. NIF:54387763P. NOMBRE_RAZON:Sample Consumer", err.Message())
+	})
+
+	t.Run("server side fault", func(t *testing.T) {
+		f := &verifactu.Fault{
+			Code:    "env:Server",
+			Message: "Codigo[401].No hay conexion a @firma afirma6.aeat",
+		}
+		err := f.Err()
+		assert.ErrorIs(t, err, verifactu.ErrServer)
+		assert.Equal(t, "401", err.Code())
+		assert.Equal(t, "No hay conexion a @firma afirma6.aeat", err.Message())
+	})
+
+	t.Run("alternative fault code prefix", func(t *testing.T) {
+		f := &verifactu.Fault{
+			Code:    "soapenv:Server",
+			Message: "Internal error",
+		}
+		err := f.Err()
+		assert.ErrorIs(t, err, verifactu.ErrServer)
+		assert.Empty(t, err.Code())
+		assert.Equal(t, "Internal error", err.Message())
+	})
+
+	t.Run("without code", func(t *testing.T) {
+		f := &verifactu.Fault{
+			Code:    "env:Client",
+			Message: "Error en la cabecera",
+		}
+		err := f.Err()
+		assert.ErrorIs(t, err, verifactu.ErrValidation)
+		assert.Empty(t, err.Code())
+		assert.Equal(t, "Error en la cabecera", err.Message())
+	})
+
+	t.Run("code without trailing period", func(t *testing.T) {
+		f := &verifactu.Fault{
+			Code:    "env:Client",
+			Message: "Codigo[4112] Error certificado",
+		}
+		err := f.Err()
+		assert.Equal(t, "4112", err.Code())
+		assert.Equal(t, "Error certificado", err.Message())
+	})
+
+	t.Run("code not at start of message", func(t *testing.T) {
+		f := &verifactu.Fault{
+			Code:    "env:Client",
+			Message: "Error en la cabecera Codigo[4104]",
+		}
+		err := f.Err()
+		assert.Empty(t, err.Code())
+		assert.Equal(t, "Error en la cabecera Codigo[4104]", err.Message())
+	})
+}

--- a/errors.go
+++ b/errors.go
@@ -7,10 +7,20 @@ import (
 
 // Standard gateway error responses
 var (
+	// ErrConnection is used when the gateway could not be reached or gave a
+	// response we're unable to understand.
 	ErrConnection = newError("connection")
+	// ErrValidation implies there is something wrong with the contents of the
+	// request that needs to be fixed before sending it again.
 	ErrValidation = newError("validation")
-	ErrDuplicate  = newError("duplicate")
-	ErrWarning    = newError("warning")
+	// ErrDuplicate is used when the gateway has already received the request.
+	ErrDuplicate = newError("duplicate")
+	// ErrWarning means the request was accepted, but the gateway reported
+	// issues that should be reviewed.
+	ErrWarning = newError("warning")
+	// ErrServer indicates the gateway had an internal problem handling the
+	// request, which may succeed if attempted again later.
+	ErrServer = newError("server")
 )
 
 // Standard error responses.

--- a/invoice_response.go
+++ b/invoice_response.go
@@ -94,11 +94,12 @@ func (r *InvoiceResponseLine) Error() error {
 	}
 }
 
-// Message provides a message body, if any.
+// Message provides the description of the issue reported by the gateway, or
+// the status of the line when no description was provided. The status is not
+// included alongside the description as it is already available separately.
 func (r *InvoiceResponseLine) Message() string {
-	txt := r.Description
-	if txt != "" {
-		return r.Status + ": " + txt
+	if r.Description != "" {
+		return r.Description
 	}
 	return r.Status
 }


### PR DESCRIPTION
Reported by a client after a sandbox rejection came back without a code, even though the code was visible inside the message:

```json
{
  "provider": "verifactu.send",
  "message": "Codigo[4104].Error en la cabecera: el valor del campo NIF del bloque ObligadoEmision no está identificado.. NIF:<redacted>. NOMBRE_RAZON:<redacted>"
}
```

Errors detected in the *header* of a request are reported as SOAP faults rather than as a `RespuestaRegFactuSistemaFacturacion`, and the fault structure has nowhere to put the VeriFactu error code — `SistemaFacturacion.wsdl` declares no fault message, `soap-envelope.xsd` only allows `faultcode`/`faultstring`/`faultactor`/`detail`, and `RespuestaSuministro.xsd` has no header level error element. AEAT sets `faultcode` to a generic `env:Client`/`env:Server` and puts the real code in the fault string, so parsing it out is the only route. Rejected *records* were unaffected — they have a real `CodigoErrorRegistro` field, which we already map.

## Changes

- `Fault` extracts the `Codigo[NNNN]` prefix, so the code lands in `Error.Code()` just like a record's code, and `Message()` returns the description without it (indentation collapsed to single spaces).
- New `ErrServer` for faults from the gateway and for 5xx statuses. The client/server distinction previously only existed in the `faultcode`, which consumers had to compare as a string; now it is in the error key, so no one needs to guess whether a numeric code is an HTTP status or a gateway code to decide what is retryable. The comparison is also on the local part of the QName, since the `env:` prefix is chosen by the server.
- Faults arriving alongside an error status code are now parsed. resty only unmarshals `SetResult` on 2xx, and the status check ran first, so a fault sent with HTTP 500 (which SOAP 1.1 mandates) collapsed into `code="500"` plus the raw XML body as the message.
- `InvoiceResponseLine.Message()` no longer prefixes the record status, which is redundant now the code is separate and is already persisted separately by the consumer.

Result for the client's case: `code: "4104"`, with the message carrying only the description.

## Note for consumers

`Error.Code()` no longer returns `env:Client`/`env:Server` for faults, it returns the gateway code. Anything switching on those strings should switch on `ErrValidation` vs. `ErrServer` instead. The matching change for `invopop/verifactu` is ready and will follow once this is tagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)